### PR TITLE
construct windows friendly url for class loading

### DIFF
--- a/src/java/org/apache/sqoop/util/ClassLoaderStack.java
+++ b/src/java/org/apache/sqoop/util/ClassLoaderStack.java
@@ -75,7 +75,7 @@ public final class ClassLoaderStack {
       }
     }
 
-    String urlPath = "jar:file://" + new File(jarFile).getAbsolutePath() + "!/";
+    String urlPath = "jar:file:" + new File(jarFile).getAbsolutePath() + "!/";
     LOG.debug("Attempting to load jar through URL: " + urlPath);
     LOG.debug("Previous classloader is " + prevClassLoader);
     URL [] jarUrlArray = {new URL(urlPath)};


### PR DESCRIPTION
Ran into a problem with class loading not working on windows. Here's a fix.
