### PR TITLE
ClassWriter list not long size error

### DIFF
--- a/src/java/org/apache/sqoop/orm/ClassWriter.java
+++ b/src/java/org/apache/sqoop/orm/ClassWriter.java
@@ -1396,6 +1396,7 @@ public class ClassWriter {
   private void parseColumn(String colName, int colType, StringBuilder sb) {
     // assume that we have __it and __cur_str vars, based on
     // __loadFromFields() code.
+	sb.append(" if(__it.hasNext()){ \n");  //add by chenshaoxing
     sb.append("    __cur_str = __it.next();\n");
     String javaType = toJavaType(colName, colType);
 
@@ -1446,6 +1447,7 @@ public class ClassWriter {
     }
 
     sb.append("    }\n\n"); // the closing '{' based on code in parseNullVal();
+    sb.append("  }\n\n");
   }
 
   /**


### PR DESCRIPTION
hive export  mysql function:
hive table data ：
id  name  age
1,chenshaoxing,20
2,hugo
second record age filed is null
exec:
sqoop export --connect jdbc:mysql://172.20.4.34:3306/test1 --username root --password root --table t_part --export-dir /csx/hive/table --input-fields-terminated-by ',' --input-null-string '\N' --input-null-non-string '\N'
RunTimeException:
Error: java.io.IOException: Can't export data, please check failed map task logs
  at org.apache.sqoop.mapreduce.TextExportMapper.map(TextExportMapper.java:112)
  at org.apache.sqoop.mapreduce.TextExportMapper.map(TextExportMapper.java:39)
  at org.apache.hadoop.mapreduce.Mapper.run(Mapper.java:145)
  at org.apache.sqoop.mapreduce.AutoProgressMapper.run(AutoProgressMapper.java:64)
  at org.apache.hadoop.mapred.MapTask.runNewMapper(MapTask.java:764)
  at org.apache.hadoop.mapred.MapTask.run(MapTask.java:340)
  at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:167)
  at java.security.AccessController.doPrivileged(Native Method)
  at javax.security.auth.Subject.doAs(Subject.java:415)
  at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1554)
  at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:162)
Caused by: java.lang.RuntimeException: Can't parse input data: 'csx'
  at t_part.__loadFromFields(t_part.java:292)
  at t_part.parse(t_part.java:230)
  at org.apache.sqoop.mapreduce.TextExportMapper.map(TextExportMapper.java:83)
  ... 10 more
Caused by: java.util.NoSuchElementException
  at java.util.ArrayList$Itr.next(ArrayList.java:834)
  at t_part.__loadFromFields(t_part.java:287)
  ... 12 more

genarate java class:
private void __loadFromFields(List<String> fields) {
    Iterator<String> __it = fields.listIterator();
    String __cur_str = null;
    try {
// if(__it.hasNext()){ 
    __cur_str = __it.next();
    if (__cur_str.equals("\N") || __cur_str.length() == 0) { this.id = null; } else {
      this.id = Long.valueOf(__cur_str);
    }

 // }

// if(__it.hasNext()){ 
    __cur_str = __it.next();
    if (__cur_str.equals("\N")) { this.name = null; } else {
      this.name = __cur_str;
    }

 // }
// this throw  Exception 
 //if(__it.hasNext()){ 
    __cur_str = __it.next();   //NoSuchElementException
    if (__cur_str.equals("\N")) { this.age = null; } else {
      this.age = __cur_str;
    }

  //}

first line list size = 3, second line list size = 2;
so add  if(__it.hasNext()){ }
