### PR TITLE
use correct mysqlimport parameter for escaped by character

### DIFF
--- a/src/java/org/apache/sqoop/mapreduce/MySQLExportMapper.java
+++ b/src/java/org/apache/sqoop/mapreduce/MySQLExportMapper.java
@@ -201,7 +201,7 @@ public class MySQLExportMapper<KEYIN, VALIN>
     }
 
     if (0 != escapedBy) {
-      args.add("--escaped-by=0x" + Integer.toString(escapedBy, 16));
+      args.add("--fields-escaped-by=0x" + Integer.toString(escapedBy, 16));
     }
 
     // These two arguments are positional and must be last.


### PR DESCRIPTION
Emailed with Abraham Elmahrek. I did not / could not (compiling sqoop failed) test this but it's a pretty trivial change.
