### PR TITLE
[SQOOP-2839]

### DIFF
--- a/src/java/org/apache/sqoop/orm/ClassWriter.java
+++ b/src/java/org/apache/sqoop/orm/ClassWriter.java
@@ -121,6 +121,8 @@ public class ClassWriter {
     // not strictly reserved words, but collides with
     // our imports
     JAVA_RESERVED_WORDS.add("Text");
+    //Fix For SQOOP-2839
+    JAVA_RESERVED_WORDS.add("PROTOCOL_VERSION");
   }
 
   public static final String PROPERTY_CODEGEN_METHODS_MAXCOLS =


### PR DESCRIPTION
On our investigation we found out this is related to Sqoop’s internal implementation. Sqoop internally creates a Java class corresponding to the table to be imported, which contains all the column names as data members. It also includes a constant named  "PROTOCOL_VERSION" and this leads to conflict between data members, if one of the column is named “PROTOCOL_VERSION”.

So in order to solve this issue , adding PROTOCOL_VERSION in reserved words list
