### PR TITLE
[SQOOP-2906] Optimize toAvroIdentifier

### DIFF
--- a/src/java/org/apache/sqoop/avro/AvroUtil.java
+++ b/src/java/org/apache/sqoop/avro/AvroUtil.java
@@ -111,44 +111,21 @@ public final class AvroUtil {
   }
 
   /**
-   * Helper function for toAvroIdentifier.
-   */
-  private static boolean isWordCharacter(char c) {
-      return (c >= 'a' && c <= 'z') ||
-             (c >= 'A' && c <= 'Z') ||
-             (c >= '0' && c <= '9') ||
-             (c == '_');
-  }
-
-  /**
    * Format candidate to avro specifics
    */
   public static String toAvroIdentifier(String candidate) {
-      String formattedCandidate;
-      int n = candidate.length();
-      char[] data = new char[n];
+        char[] data = candidate.toCharArray();
+        int stringIndex = 0;
 
-      int stringIndex = 0;
-      for (int i = 0; i < n; ++i) {
-          if (!isWordCharacter(candidate.charAt(i))) {
-              ++i;
-              while (i < n && !isWordCharacter(candidate.charAt(i)))
-                  ++i;
-              if (i == n)
-                  break;
-          }
-          data[stringIndex++] = candidate.charAt(i);
-      }
-      char initial = data[0];
-      if ((initial >= 'a' && initial <= 'z') || 
-          (initial) >= 'A' && initial <= 'Z' || 
-          (initial == '_') ) {
-          formattedCandidate = new String(data).trim();
-      } else {
-          formattedCandidate = new String("AVRO_" + new String(data).trim());
-      }
+        for(char c:data)
+            if(Character.isLetterOrDigit(c) || c == '_')
+                data[stringIndex++] = c;
 
-      return formattedCandidate;
+        char initial = data[0];
+        if(Character.isLetter(initial) || initial == '_')
+            return new String(data, 0, stringIndex);
+        else
+            return "AVRO_".concat(new String(data, 0, stringIndex));
   }
 
   /**

--- a/src/java/org/apache/sqoop/avro/AvroUtil.java
+++ b/src/java/org/apache/sqoop/avro/AvroUtil.java
@@ -111,15 +111,44 @@ public final class AvroUtil {
   }
 
   /**
+   * Helper function for toAvroIdentifier.
+   */
+  private static boolean isWordCharacter(char c) {
+      return (c >= 'a' && c <= 'z') ||
+             (c >= 'A' && c <= 'Z') ||
+             (c >= '0' && c <= '9') ||
+             (c == '_');
+  }
+
+  /**
    * Format candidate to avro specifics
    */
   public static String toAvroIdentifier(String candidate) {
-    String formattedCandidate = candidate.replaceAll("\\W+", "_");
-    if (formattedCandidate.substring(0,1).matches("[a-zA-Z_]")) {
+      String formattedCandidate;
+      int n = candidate.length();
+      char[] data = new char[n];
+
+      int stringIndex = 0;
+      for (int i = 0; i < n; ++i) {
+          if (!isWordCharacter(candidate.charAt(i))) {
+              ++i;
+              while (i < n && !isWordCharacter(candidate.charAt(i)))
+                  ++i;
+              if (i == n)
+                  break;
+          }
+          data[stringIndex++] = candidate.charAt(i);
+      }
+      char initial = data[0];
+      if ((initial >= 'a' && initial <= 'z') || 
+          (initial) >= 'A' && initial <= 'Z' || 
+          (initial == '_') ) {
+          formattedCandidate = new String(data).trim();
+      } else {
+          formattedCandidate = new String("AVRO_" + new String(data).trim());
+      }
+
       return formattedCandidate;
-    } else {
-      return "AVRO_" + formattedCandidate;
-    }
   }
 
   /**

--- a/src/java/org/apache/sqoop/avro/AvroUtil.java
+++ b/src/java/org/apache/sqoop/avro/AvroUtil.java
@@ -114,18 +114,21 @@ public final class AvroUtil {
    * Format candidate to avro specifics
    */
   public static String toAvroIdentifier(String candidate) {
-        char[] data = candidate.toCharArray();
-        int stringIndex = 0;
+    char[] data = candidate.toCharArray();
+    int stringIndex = 0;
 
-        for(char c:data)
-            if(Character.isLetterOrDigit(c) || c == '_')
-                data[stringIndex++] = c;
+    for (char c:data) {
+      if (Character.isLetterOrDigit(c) || c == '_') {
+        data[stringIndex++] = c;
+      }
+    }
 
-        char initial = data[0];
-        if(Character.isLetter(initial) || initial == '_')
-            return new String(data, 0, stringIndex);
-        else
-            return "AVRO_".concat(new String(data, 0, stringIndex));
+    char initial = data[0];
+    if (Character.isLetter(initial) || initial == '_') {
+      return new String(data, 0, stringIndex);
+    } else {
+      return "AVRO_".concat(new String(data, 0, stringIndex));
+    }
   }
 
   /**

--- a/src/java/org/apache/sqoop/avro/AvroUtil.java
+++ b/src/java/org/apache/sqoop/avro/AvroUtil.java
@@ -115,11 +115,16 @@ public final class AvroUtil {
    */
   public static String toAvroIdentifier(String candidate) {
     char[] data = candidate.toCharArray();
+    boolean skip = false;
     int stringIndex = 0;
 
     for (char c:data) {
       if (Character.isLetterOrDigit(c) || c == '_') {
         data[stringIndex++] = c;
+        skip = false;
+      } else if(!skip) {
+        data[stringIndex++] = '_';
+        skip = true;
       }
     }
 


### PR DESCRIPTION
Hi all

Our distributed profiler indicated some inefficiencies in the AvroUtil.toAvroIdentifier method, more specifically, the use of Regex patterns. This can be directly observed from the FlameGraph generated by this profiler (https://jhermans.web.cern.ch/jhermans/sqoop_avro_flamegraph.svg). We implemented an optimization, and compared this with the original method. On our testing machine, the optimization by itself is 500% (on average) more efficient compared to the original implementation. We have yet to test how this optimization will influence the performance of user jobs.

Any suggestions or remarks are welcome.

Kind regards,

Joeri

Special thanks to @dlanza1 for the second optimization! :+1: 

**[edit]**
We tested a custom JAR with this method on our cluster, and we have an increased throughput (writing to Parquet) of 200-300% depending on the load.
