### PR TITLE
[SQOOP-2916]

### DIFF
--- a/connector/connector-generic-jdbc/src/main/java/org/apache/sqoop/connector/jdbc/GenericJdbcToInitializer.java
+++ b/connector/connector-generic-jdbc/src/main/java/org/apache/sqoop/connector/jdbc/GenericJdbcToInitializer.java
@@ -122,13 +122,24 @@ public class GenericJdbcToInitializer extends Initializer<LinkConfiguration, ToJ
     String tableSql = toJobConfig.toJobConfig.sql;
     String tableColumns = toJobConfig.toJobConfig.columns;
 
-    if (tableName != null && tableSql != null) {
-      // when both fromTable name and fromTable sql are specified:
-      throw new SqoopException(
-          GenericJdbcConnectorError.GENERIC_JDBC_CONNECTOR_0007);
+    if (tableSql != null) {
+        // when toTable sql is specified:
 
-    } else if (tableName != null) {
-      // when fromTable name is specified:
+        if (tableSql.indexOf(
+            GenericJdbcConnectorConstants.SQL_PARAMETER_MARKER) == -1) {
+          // make sure parameter marker is in the specified sql
+          throw new SqoopException(
+              GenericJdbcConnectorError.GENERIC_JDBC_CONNECTOR_0013);
+        }
+
+        if (tableColumns == null) {
+          dataSql = tableSql;
+        } else {
+          throw new SqoopException(
+              GenericJdbcConnectorError.GENERIC_JDBC_CONNECTOR_0014);
+        }
+      }else if (tableName != null) {
+      // when toTable name is specified:
       if(stageEnabled) {
         LOG.info("Stage has been enabled.");
         LOG.info("Use stageTable: " + stageTableName +
@@ -179,23 +190,7 @@ public class GenericJdbcToInitializer extends Initializer<LinkConfiguration, ToJ
         builder.append(")");
         dataSql = builder.toString();
       }
-    } else if (tableSql != null) {
-      // when fromTable sql is specified:
-
-      if (tableSql.indexOf(
-          GenericJdbcConnectorConstants.SQL_PARAMETER_MARKER) == -1) {
-        // make sure parameter marker is in the specified sql
-        throw new SqoopException(
-            GenericJdbcConnectorError.GENERIC_JDBC_CONNECTOR_0013);
-      }
-
-      if (tableColumns == null) {
-        dataSql = tableSql;
-      } else {
-        throw new SqoopException(
-            GenericJdbcConnectorError.GENERIC_JDBC_CONNECTOR_0014);
-      }
-    } else {
+    }  else {
       // when neither are specified:
       throw new SqoopException(
           GenericJdbcConnectorError.GENERIC_JDBC_CONNECTOR_0008);

--- a/connector/connector-generic-jdbc/src/main/java/org/apache/sqoop/connector/jdbc/GenericJdbcToInitializer.java
+++ b/connector/connector-generic-jdbc/src/main/java/org/apache/sqoop/connector/jdbc/GenericJdbcToInitializer.java
@@ -124,7 +124,6 @@ public class GenericJdbcToInitializer extends Initializer<LinkConfiguration, ToJ
 
     if (tableSql != null) {
         // when toTable sql is specified:
-
         if (tableSql.indexOf(
             GenericJdbcConnectorConstants.SQL_PARAMETER_MARKER) == -1) {
           // make sure parameter marker is in the specified sql

--- a/connector/connector-generic-jdbc/src/main/java/org/apache/sqoop/connector/jdbc/configuration/ToJobConfig.java
+++ b/connector/connector-generic-jdbc/src/main/java/org/apache/sqoop/connector/jdbc/configuration/ToJobConfig.java
@@ -52,9 +52,6 @@ public class ToJobConfig {
       if (config.tableName == null && config.sql == null) {
         addMessage(Status.ERROR, "Either table name or SQL must be specified");
       }
-      if (config.tableName != null && config.sql != null) {
-        addMessage(Status.ERROR, "Both table name and SQL cannot be specified");
-      }
       if (config.tableName == null && config.stageTableName != null) {
         addMessage(Status.ERROR,
             "Stage table name cannot be specified without specifying table name");

--- a/connector/connector-generic-jdbc/src/main/java/org/apache/sqoop/connector/jdbc/configuration/ToJobConfig.java
+++ b/connector/connector-generic-jdbc/src/main/java/org/apache/sqoop/connector/jdbc/configuration/ToJobConfig.java
@@ -45,7 +45,7 @@ public class ToJobConfig {
 
   @Input
   public Boolean shouldClearStageTable;
-
+  
   public static class ConfigValidator extends AbstractValidator<ToJobConfig> {
     @Override
     public void validate(ToJobConfig config) {


### PR DESCRIPTION
When completing the TO part of a job, people cannot state custom SQL statement by any means:
1. When both TableName and SQL statement are provided, it reports the'GENERIC_JDBC_CONNECTOR_0007("The table name and the table sql cannot be specified together")' exception.
2. When only the SQL statement is provided, it reports the 'Both table name and SQL cannot be specified' exception.

The modification we have made is simply to allow the TableName and the SQL statement can be input together and in this case, the SQL have the higher priority to be executed.
