### PR TITLE
[SQOOP-3002] sqoop merge tool composite merge-key

### DIFF
--- a/src/java/org/apache/sqoop/mapreduce/MergeMapperBase.java
+++ b/src/java/org/apache/sqoop/mapreduce/MergeMapperBase.java
@@ -76,9 +76,10 @@ public class MergeMapperBase<INKEY, INVAL>
     }
     Object keyObj = null;
     if (keyColName.contains(",")) {
+        String connectStr = new String(new byte[]{1});
         StringBuilder keyFieldsSb = new StringBuilder();
         for (String str : keyColName.split(",")) {
-            keyFieldsSb.append("+").append(fieldMap.get(str).toString());
+            keyFieldsSb.append(connectStr).append(fieldMap.get(str).toString());
         }
         keyObj = keyFieldsSb;
     } else {

--- a/src/java/org/apache/sqoop/mapreduce/MergeMapperBase.java
+++ b/src/java/org/apache/sqoop/mapreduce/MergeMapperBase.java
@@ -74,7 +74,17 @@ public class MergeMapperBase<INKEY, INVAL>
     if (null == fieldMap) {
       throw new IOException("No field map in record " + r);
     }
-    Object keyObj = fieldMap.get(keyColName);
+    Object keyObj = null;
+    if (keyColName.contains(",")) {
+        StringBuilder keyFieldsSb = new StringBuilder();
+        for (String str : keyColName.split(",")) {
+            keyFieldsSb.append("+").append(fieldMap.get(str).toString());
+        }
+        keyObj = keyFieldsSb;
+    } else {
+        keyObj = fieldMap.get(keyColName);
+    }
+
     if (null == keyObj) {
       throw new IOException("Cannot join values on null key. "
           + "Did you specify a key column that exists?");


### PR DESCRIPTION
JIRA Issue:https://issues.apache.org/jira/browse/SQOOP-3002
Sqoop Merge Tool can only specify one column by using --merge-key argument.
When i need to specify two or more column, Sqoop-1.4.6 will throw an Exception.
