### PR TITLE
[SQOOP-3010] Fix for Sqoop should not allow --as-parquetfile when job…

### DIFF
--- a/src/java/org/apache/sqoop/tool/BaseSqoopTool.java
+++ b/src/java/org/apache/sqoop/tool/BaseSqoopTool.java
@@ -1591,6 +1591,13 @@ public abstract class BaseSqoopTool extends com.cloudera.sqoop.tool.SqoopTool {
         + " option." + HELP_STR);
 
     }
+    
+    if (options.getFileLayout() == SqoopOptions.FileLayout.ParquetFile) {
+      throw new InvalidOptionsException("HCatalog job is not compatible with "
+        + " ParquetFile format option " + FMT_PARQUETFILE_ARG
+        + " option." + HELP_STR);
+
+    }
 
     if (options.getFileLayout() == SqoopOptions.FileLayout.SequenceFile) {
       throw new InvalidOptionsException("HCatalog job  is not compatible with "


### PR DESCRIPTION
… type is hcatalog
