### PR TITLE
SQOOP-3411: PostgresMetaConnectIncrementalImportTest fails if metastore tables are absent from the database

### DIFF
--- a/src/test/org/apache/sqoop/metastore/MetaConnectIncrementalImportTestBase.java
+++ b/src/test/org/apache/sqoop/metastore/MetaConnectIncrementalImportTestBase.java
@@ -68,11 +68,24 @@ public abstract class MetaConnectIncrementalImportTestBase extends BaseSqoopTest
     @Before
     public void setUp() {
         super.setUp();
+        try {
+            initMetastoreConnection();
+            resetTable();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        resetMetastoreSchema();
     }
 
     @After
     public void tearDown() {
         super.tearDown();
+        resetMetastoreSchema();
+        try {
+            cm.close();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     protected String[] getIncrementalJob(String metaConnectString, String metaUser, String metaPass) {
@@ -123,12 +136,6 @@ public abstract class MetaConnectIncrementalImportTestBase extends BaseSqoopTest
 
     @Test
     public void testIncrementalJob() throws SQLException {
-        resetTable();
-
-        initMetastoreConnection();
-
-        resetMetastoreSchema();
-
         //creates Job
         createJob();
 
@@ -148,8 +155,6 @@ public abstract class MetaConnectIncrementalImportTestBase extends BaseSqoopTest
 
         //Ensures the last incremental value is updated correctly.
         checkIncrementalState(2);
-
-        cm.close();
     }
 
     private void checkIncrementalState(int expected) throws SQLException {

--- a/src/test/org/apache/sqoop/metastore/MetaConnectIncrementalImportTestBase.java
+++ b/src/test/org/apache/sqoop/metastore/MetaConnectIncrementalImportTestBase.java
@@ -195,9 +195,13 @@ public abstract class MetaConnectIncrementalImportTestBase extends BaseSqoopTest
             metastoreStatement.execute("DROP TABLE " + cm.escapeTableName("SQOOP_ROOT"));
             metastoreStatement.execute("DROP TABLE " + cm.escapeTableName("SQOOP_SESSIONS"));
             connMeta.commit();
-        }
-        catch (Exception e) {
-            LOG.error( e.getLocalizedMessage() );
+        } catch (Exception e) {
+            LOG.error(e.getLocalizedMessage());
+            try {
+                connMeta.rollback();
+            } catch (SQLException e1) {
+                LOG.error(e1.getLocalizedMessage());
+            }
         }
     }
 

--- a/src/test/org/apache/sqoop/metastore/MetaConnectIncrementalImportTestBase.java
+++ b/src/test/org/apache/sqoop/metastore/MetaConnectIncrementalImportTestBase.java
@@ -204,8 +204,8 @@ public abstract class MetaConnectIncrementalImportTestBase extends BaseSqoopTest
             LOG.error(e.getLocalizedMessage());
             try {
                 connMeta.rollback();
-            } catch (SQLException e1) {
-                LOG.error(e1.getLocalizedMessage());
+            } catch (SQLException innerException) {
+                LOG.error(innerException.getLocalizedMessage());
             }
         }
     }


### PR DESCRIPTION
It turned out that if the DROP TABLE command in org.apache.sqoop.metastore.MetaConnectIncrementalImportTestBase#resetMetastoreSchema fails the transaction is not rolled back explicitly which leads to an error when the next SQL statement is executed in the same connection.

An extra cleanup logic is added to tearDown method to make sure the tables are deleted.