### PR TITLE
SQOOP-3413: TestMainframeManager does not restore the inner state of AccumuloUtil

### DIFF
--- a/src/test/org/apache/sqoop/manager/TestMainframeManager.java
+++ b/src/test/org/apache/sqoop/manager/TestMainframeManager.java
@@ -140,6 +140,7 @@ public class TestMainframeManager extends BaseSqoopTestCase {
     } catch (IOException e) {
       fail("No IOException should be thrown!");
     } finally {
+      AccumuloUtil.setAlwaysNoAccumuloJarMode(false);
       opts.setAccumuloTable(null);
     }
   }


### PR DESCRIPTION
…loJarPresent now restores the inner state of AccumuloUtil.