### PR TITLE
SQOOP-3393 TestNetezzaExternalTableExportMapper hangs

### DIFF
--- a/src/test/org/apache/sqoop/mapreduce/db/netezza/TestNetezzaExternalTableExportMapper.java
+++ b/src/test/org/apache/sqoop/mapreduce/db/netezza/TestNetezzaExternalTableExportMapper.java
@@ -53,6 +53,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@Category(UnitTest.class)
 public class TestNetezzaExternalTableExportMapper {
 
   // chained rule, see #rules

--- a/src/test/org/apache/sqoop/mapreduce/db/netezza/TestNetezzaExternalTableExportMapper.java
+++ b/src/test/org/apache/sqoop/mapreduce/db/netezza/TestNetezzaExternalTableExportMapper.java
@@ -44,6 +44,7 @@ import java.io.IOException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -200,6 +201,7 @@ public class TestNetezzaExternalTableExportMapper {
     Mapper.Context context = mock(Mapper.Context.class);
 
     Configuration conf = new Configuration();
+    conf.set("mapreduce.task.id", UUID.randomUUID().toString());
     when(context.getConfiguration()).thenReturn(conf);
 
     TaskAttemptID taskAttemptID = new TaskAttemptID();


### PR DESCRIPTION
Looks like this test only fails when run with all other uniTests. From the logs I've found, that there's already a task_attempt directory (which we're falling back to in absence of a `mapreduce.task.id`), and we're hanging because of that. Most probably another test is creating that too.

The proposed solution is to simulate a unique `mapreduce.task.id` during the tests.