### PR TITLE
SQOOP-3429 Bump Hadoop to 2.9.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ javaSourceCompatibilityVersion=1.8
 
 avroVersion=1.8.1
 parquetVersion=1.9.0
-hadoopVersion=2.8.0
+hadoopVersion=2.9.2
 aspectjVersion=1.7.4
 zookeeperVersion=3.4.6
 hbaseVersion=1.2.4

--- a/ivy/libraries.properties
+++ b/ivy/libraries.properties
@@ -59,7 +59,7 @@ accumulo.version=1.6.2
 
 slf4j.version=1.7.7
 
-hadoop.version=2.8.0
+hadoop.version=2.9.2
 hbase.version=1.2.4
 hcatalog.version=2.1.1
 kryo.version=3.0.3


### PR DESCRIPTION
We would like to bump Hadoop to make sure that it runs on GCP. Hadoop 2.6 isn't available anymore: https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-release-1.0

The latest stable release of Dataproc is on Hadoop 2.9.2: https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-release-1.3

This is similar to other cloud providers, and also applicable to vanilla Hadoop.

Jira: https://jira.apache.org/jira/browse/SQOOP-3429