### PR TITLE
SQOOP-3435 Avoid NullPointerException due to different JSONObject library in classpath

### DIFF
--- a/src/java/org/apache/sqoop/util/SqoopJsonUtil.java
+++ b/src/java/org/apache/sqoop/util/SqoopJsonUtil.java
@@ -40,7 +40,8 @@ public class SqoopJsonUtil {
   }
 
   public static String getJsonStringforMap(Map<String, String> map) {
-    JSONObject pathPartMap = new JSONObject(map);
+    Map<String, String> mapToUse = (map == null) ? Collections.emptyMap() : map;
+    JSONObject pathPartMap = new JSONObject(mapToUse);
     return pathPartMap.toString();
   }
 


### PR DESCRIPTION


Sqoop is expecting the classpath to have org.json [1] as the dependency
but if one uses HADOOP_CLASSPATH to initialize sqoop executor
with com.tdunning open json [2] as the resolution of org.json.JSONObject.
it failed with NullPointerException

1. https://mvnrepository.com/artifact/org.json/json/20090211
2. https://github.com/tdunning/open-json/blob/rc1.8/src/main/java/org/json/JSONObject.java#L141-L155