### PR TITLE
Fix SQOOP-1946: split-by Oracle DATE column causes error ORA-01861: literal does not match format string

### DIFF
--- a/src/java/org/apache/sqoop/manager/OracleManager.java
+++ b/src/java/org/apache/sqoop/manager/OracleManager.java
@@ -455,6 +455,15 @@ public class OracleManager
     super.importTable(context);
   }
 
+  @Override
+  public void importQuery(com.cloudera.sqoop.manager.ImportJobContext context)
+      throws IOException, ImportException {
+    context.setConnManager(this);
+    // Specify the Oracle-specific DBInputFormat for import.
+    context.setInputFormat(OracleDataDrivenDBInputFormat.class);
+    super.importQuery(context);
+  }
+
   /**
    * Export data stored in HDFS into a table in a database.
    */

--- a/src/java/org/apache/sqoop/manager/OracleManager.java
+++ b/src/java/org/apache/sqoop/manager/OracleManager.java
@@ -456,7 +456,7 @@ public class OracleManager
   }
 
   @Override
-  public void importQuery(com.cloudera.sqoop.manager.ImportJobContext context)
+  public void importQuery(org.apache.sqoop.manager.ImportJobContext context)
       throws IOException, ImportException {
     context.setConnManager(this);
     // Specify the Oracle-specific DBInputFormat for import.


### PR DESCRIPTION
Fix [SQOOP-1946](https://issues.apache.org/jira/browse/SQOOP-1946)

This issue occurred when using --query, the ConnManager and InputFormat of ImportJobContext not set to Oracle ones.

Also fix this: [Sqoop split-by date wants to compare a timestamp with milliseconds to oracle date](
https://community.cloudera.com/t5/Support-Questions/Sqoop-split-by-date-wants-to-compare-a-timestamp-with/td-p/36386)