### PR TITLE
SQOOP-3462 Sqoop ant build fails due to outdated maven repo URLs

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -169,9 +169,9 @@
   <property name="ivysettings.xml" location="${ivy.dir}/ivysettings.xml"/>
   <property name="ivy.jar" location="${lib.dir}/ivy-${ivy.version}.jar"/>
   <property name="ivy_repo_url"
-  value="http://repo2.maven.org/maven2/org/apache/ivy/ivy/${ivy.version}/ivy-${ivy.version}.jar" />
+  value="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.version}/ivy-${ivy.version}.jar" />
   <property name="mvn_repo_url"
-  value="http://repo2.maven.org/maven2/org/apache/maven/maven-ant-tasks/${mvn.version}/maven-ant-tasks-${mvn.version}.jar"/>
+  value="https://repo1.maven.org/maven2/org/apache/maven/maven-ant-tasks/${mvn.version}/maven-ant-tasks-${mvn.version}.jar"/>
   <property name="mvn.jar"
       location="${build.dir}/maven-ant-tasks-${mvn.version}.jar" />
   <property name="build.ivy.dir" location="${build.dir}/ivy" />

--- a/ivy/ivysettings.xml
+++ b/ivy/ivysettings.xml
@@ -23,7 +23,7 @@ under the License.
   see http://www.jayasoft.org/ivy/doc/configuration
   -->
   <!-- you can override this property to use mirrors
-          http://repo1.maven.org/maven2/
+          https://repo1.maven.org/maven2/
           http://mirrors.dotsrc.org/maven2
           http://ftp.ggi-project.org/pub/packages/maven2
           http://mirrors.sunsite.dk/maven2
@@ -31,7 +31,7 @@ under the License.
           http://ibiblio.lsu.edu/main/pub/packages/maven2
           http://www.ibiblio.net/pub/packages/maven2
   -->
-  <property name="repo.maven.org" value="http://repo1.maven.org/maven2/"
+  <property name="repo.maven.org" value="https://repo1.maven.org/maven2/"
       override="false"/>
   <property name="snapshot.apache.org"
       value="https://repository.apache.org/content/repositories/snapshots/"


### PR DESCRIPTION
use https://repo1.maven.org URL int ant build.