### PR TITLE
SQOOP-3465: InformationSchemaManager doesn't sort column names in ordinal orders

### DIFF
--- a/src/java/org/apache/sqoop/manager/InformationSchemaManager.java
+++ b/src/java/org/apache/sqoop/manager/InformationSchemaManager.java
@@ -52,7 +52,8 @@ public abstract class InformationSchemaManager
     return
       "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS "
     + "WHERE TABLE_SCHEMA = (" + getSchemaQuery() + ") "
-    + "  AND TABLE_NAME = '" + tableName + "' ";
+    + "  AND TABLE_NAME = '" + tableName + "' "
+    + "  ORDER BY ORDINAL_POSITION";
   }
 
   @Override


### PR DESCRIPTION
Fix [SQOOP-3465](https://issues.apache.org/jira/browse/SQOOP-3465)

InformationSchemaManger's method getListColumnsQuery returns a list of columns without 'ORDER BY ORDINAL_POSITION', hence the column names are order by alphabetical order.

That may cause columns mismatching issue in codegen phase, and finally results in failed data transport.