### PR TITLE
FIX data duplicated (oracle direct mode)

### DIFF
--- a/src/java/org/apache/sqoop/manager/oracle/OraOopOracleQueries.java
+++ b/src/java/org/apache/sqoop/manager/oracle/OraOopOracleQueries.java
@@ -302,6 +302,7 @@ public final class OraOopOracleQueries {
         + "         AND s.owner=t.owner "
         + "         AND s.segment_name=t.table_name) "
         + "    ) "
+        + "AND s.segment_type!='INDEX PARTITION'"
         + "AND s.partition_name=pl.partition_name";
 
     PreparedStatement statement = connection.prepareStatement(sql);


### PR DESCRIPTION
FIX duplicated data when found both 'TABLE PARTITION' and 'INDEX PARTITION' on same partition.