### PR TITLE
Build and test on both AMD64 and ARM64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,15 @@ sudo: true
 language: java
 jdk:
 - oraclejdk8
+
+jobs:
+  include:
+    - name: "Build and test on ARM64 CPU architecture"
+      arch: arm64
+      env: TEST_TASK=test
+
+        
+    
 services:
 - docker
 env:
@@ -61,6 +70,14 @@ before_install:
     ./src/scripts/thirdpartytest/start-thirdpartytest-db-containers.sh oracle;
     sleep 90;
   fi
+
+install:
+  - if [ "${TRAVIS_CPU_ARCH}" == "arm64" ]; then 
+      sudo apt-get -m install openjdk-8-jdk;
+      export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-arm64;
+      export PATH=$JAVA_HOME/bin:$PATH; 
+    fi
+    
 script:
 - ./gradlew $TEST_TASK;
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ jdk:
 
 jobs:
   include:
-    - name: "Build and test on ARM64 CPU architecture"
+    - name: "Linux ARM64"
       arch: arm64
-      env: TEST_TASK=test
+      env: TEST_TASK=unitTest
 
         
     


### PR DESCRIPTION
More and more software development is being done on ARM64 CPU architecture.
It would be good if Sqoop is being regularly tested on ARM64.

X-ref: https://issues.apache.org/jira/browse/SQOOP-3483